### PR TITLE
Make PGPASSWORD available to psql

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,6 @@ export DB_PORT="${DB_PORT:-5432}"
 export DB_NAME="${DB_NAME:-mediafiledata}"
 export DB_USER="${DB_USER:-openslides}"
 export DB_PASSWORD="${DB_PASSWORD:-openslides}"
-PGPASSWORD="$DB_PASSWORD"
 
 until pg_isready -h "$DB_HOST" -p "$DB_PORT"; do
   echo "Waiting for Postgres server '$DB_HOST' to become available..."
@@ -13,6 +12,6 @@ until pg_isready -h "$DB_HOST" -p "$DB_PORT"; do
 done
 
 # Create schema in postgresql
-psql -1 -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" -f src/schema.sql
+PGPASSWORD="$DB_PASSWORD" psql -1 -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" -f src/schema.sql
 
 exec "$@"


### PR DESCRIPTION
Since the env is not exported it should be set on the command. Previously this led to the following error:
2021-02-05T10:38:56.034+01:00	Password for user openslides:
2021-02-05T10:38:56.042+01:00	psql: fe_sendauth: no password supplied