### PR TITLE
filter out non-latin1 chars before setting Content-Disposition header

### DIFF
--- a/src/mediaserver.py
+++ b/src/mediaserver.py
@@ -65,7 +65,9 @@ def serve_files(file_id, file_type):
 
     block_size = app.config["MEDIA_BLOCK_SIZE"]
     response = Response(chunked(block_size, data), mimetype=mimetype)
-    response.headers["Content-Disposition"] = f'inline; filename="{filename}"'
+    # http headers can only be encoded using latin1
+    filename_latin1 = filename.encode('latin1',errors='replace').decode('latin1')
+    response.headers["Content-Disposition"] = f'inline; filename="{filename_latin1}"'
     if auth_header:
         response.headers[AUTH_HEADER] = auth_header
     return response


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
states, that the filename in the 'Content-Disposition' is used as default name for saving the file when used together with 'attachment; '.
So at first it didn't make sense to me to include the filename at all, since we're using 'inline; '
However it seems firefox still uses the filename when pressing Ctrl-S on the inline page (chromium doesn't btw) so there actually is use in including the filename.

Since we ran into issues though when filenames had non-latin1 characters in them, I solved this by manually latin1-encoding them using the `errors=replace` handler, effectively replacing all non-latin1 chars with '?'.