### PR TITLE
Update content disposition to attachment

### DIFF
--- a/src/mediaserver.py
+++ b/src/mediaserver.py
@@ -62,7 +62,9 @@ def serve(file_id):
     response = Response(chunked(block_size, data), mimetype=mimetype)
     # http headers can only be encoded using latin1
     filename_latin1 = filename.encode("latin1", errors="replace").decode("latin1")
-    response.headers["Content-Disposition"] = f'inline; filename="{filename_latin1}"'
+    response.headers[
+        "Content-Disposition"
+    ] = f'attachment; filename="{filename_latin1}"'
 
     client_cache_duration = int(app.config["MEDIA_CLIENT_CACHE_DURATION"] or 0)
     if client_cache_duration > 0 and not is_dev_mode():


### PR DESCRIPTION
This pr changes the content disposition header for file downloads from `inline` to `attachment`. With this change files will no longer be displayed by the browser but instead directly downloaded. 

This does not affect any assets that are used by the page (e.g. projected pdfs, fonts, web logos, logos within pdfs).