### PR TITLE
Use postgres 15 images + debian bookworm images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.5-slim-buster
+FROM python:3.8.5-slim-bookworm
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.5-slim-bookworm
+FROM python:3.10.13-slim-bookworm
 
 WORKDIR /app
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.10.3-slim-bookworm
+FROM python:3.10.13-slim-bookworm
 
 RUN apt-get -y update && apt-get install --no-install-recommends -y \
     postgresql-client libpq-dev gcc libc-dev git

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.10.3-slim-buster
+FROM python:3.10.3-slim-bookworm
 
 RUN apt-get -y update && apt-get install --no-install-recommends -y \
     postgresql-client libpq-dev gcc libc-dev git

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,4 +1,4 @@
-FROM python:3.10.3-slim-buster
+FROM python:3.10.3-slim-bookworm
 
 RUN apt-get -y update && apt-get -y upgrade && \
     apt-get install --no-install-recommends -y wait-for-it \

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,4 +1,4 @@
-FROM python:3.10.3-slim-bookworm
+FROM python:3.10.13-slim-bookworm
 
 RUN apt-get -y update && apt-get -y upgrade && \
     apt-get install --no-install-recommends -y wait-for-it \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         secrets:
             - postgres_password
     postgres:
-        image: postgres:13
+        image: postgres:15
         environment:
             - POSTGRES_USER=openslides
             - POSTGRES_PASSWORD=openslides

--- a/tests/dummy_presenter/Dockerfile.dummy_presenter
+++ b/tests/dummy_presenter/Dockerfile.dummy_presenter
@@ -1,4 +1,4 @@
-FROM python:3.10.3-slim-buster
+FROM python:3.10.3-slim-bookworm
 
 WORKDIR /app
 

--- a/tests/dummy_presenter/Dockerfile.dummy_presenter
+++ b/tests/dummy_presenter/Dockerfile.dummy_presenter
@@ -1,4 +1,4 @@
-FROM python:3.10.3-slim-bookworm
+FROM python:3.10.13-slim-bookworm
 
 WORKDIR /app
 


### PR DESCRIPTION
Apart from debian being sensical on it's own, buster packages include postgres software for v11 - bookworm does for v15.