### PR TITLE
Undeprecating used Make Targets

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -22,4 +22,4 @@ jobs:
       run: make flake8
 
     - name: Stop containers
-      run: make stop-tests
+      run: make stop-tests-ci

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,20 @@ lint:
 run-tests-ci: | start-test-setup
 	docker compose -f docker-compose.test.yml exec -T tests pytest
 
+# CI
+
+check-black:
+	docker compose -f docker-compose.test.yml exec -T tests black --check --diff src/ tests/
+
+check-isort:
+	docker compose -f docker-compose.test.yml exec -T tests isort --check-only --diff src/ tests/
+
+flake8:
+	docker compose -f docker-compose.test.yml exec -T tests flake8 src/ tests/
+
+stop-tests-ci:
+	docker compose -f docker-compose.test.yml down
+
 # Cleanup
 
 run-cleanup: | build-dev
@@ -41,21 +55,6 @@ run-dev run-dev-attach run-dev-attached run-dev-standalone run-dev-interactive s
 
 build-dummy-autoupdate: | deprecation-warning
 	docker build . -f tests/dummy_autoupdate/Dockerfile.dummy_autoupdate --tag openslides-media-dummy-autoupdate
-
-check-black:
-	@make deprecation-warning-alternative ALTERNATIVE="run-lint"
-	docker compose -f docker-compose.test.yml exec -T tests black --check --diff src/ tests/
-
-check-isort:
-	@make deprecation-warning-alternative ALTERNATIVE="run-lint"
-	docker compose -f docker-compose.test.yml exec -T tests isort --check-only --diff src/ tests/
-
-flake8:
-	@make deprecation-warning-alternative ALTERNATIVE="run-lint"
-	docker compose -f docker-compose.test.yml exec -T tests flake8 src/ tests/
-
-stop-tests:
-	docker compose -f docker-compose.test.yml down
 
 start-test-setup: | deprecation-warning build-dev build-tests build-dummy-autoupdate
 	docker compose -f docker-compose.test.yml up -d

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,6 @@ run-tests:
 lint:
 	bash dev/run-lint.sh -l
 
-run-tests-ci: | start-test-setup
-	docker compose -f docker-compose.test.yml exec -T tests pytest
-
 # CI
 
 check-black:
@@ -35,6 +32,9 @@ flake8:
 
 stop-tests-ci:
 	docker compose -f docker-compose.test.yml down
+
+run-tests-ci: | start-test-setup
+	docker compose -f docker-compose.test.yml exec -T tests pytest
 
 # Cleanup
 


### PR DESCRIPTION
Make targets that are still in use by GitHub Workflows are marked as deprecated